### PR TITLE
Design/#11/take test/test header UI

### DIFF
--- a/nonsoolmateClient/src/pages/Main.tsx
+++ b/nonsoolmateClient/src/pages/Main.tsx
@@ -1,3 +1,0 @@
-export default function Main() {
-  return <div>라우터 메인 페이지 예시 화면입니다</div>;
-}

--- a/nonsoolmateClient/src/router.tsx
+++ b/nonsoolmateClient/src/router.tsx
@@ -1,5 +1,5 @@
 import Error from "error";
-import Main from "@pages/Main";
+import TakeTest from "takeTest";
 import { createBrowserRouter } from "react-router-dom";
 import RootLayout from "layout/RootLayout";
 
@@ -8,6 +8,6 @@ export const router = createBrowserRouter([
     path: "/",
     element: <RootLayout />,
     errorElement: <Error />,
-    children: [{ path: "/example", element: <Main /> }],
+    children: [{ path: "/takeTest", element: <TakeTest /> }],
   },
 ]);

--- a/nonsoolmateClient/src/takeTest/components/TestHeader.tsx
+++ b/nonsoolmateClient/src/takeTest/components/TestHeader.tsx
@@ -21,7 +21,10 @@ const TestHeaderContainer = styled.header`
   ${commonFlex};
 
   justify-content: space-between;
+  position: sticky;
+  top: 0;
   padding: 1.7rem 3.6rem 1.3rem;
+  background-color: ${({ theme }) => theme.colors.white};
   box-shadow: 0 0 1.2rem 0 ${({ theme }) => theme.colors.grey_200};
 `;
 const TestCloseButton = styled(mainButtonStyle)`

--- a/nonsoolmateClient/src/takeTest/components/TestHeader.tsx
+++ b/nonsoolmateClient/src/takeTest/components/TestHeader.tsx
@@ -1,3 +1,44 @@
+import { commonFlex, lightBlueButtonStyle, mainButtonStyle } from "style/commonStyle";
+import styled from "styled-components";
+import Timer from "./Timer";
+import { LeftArrowBlackBtn } from "@assets/index";
+
 export default function TestHeader() {
-  return <div>TestHeader</div>;
+  return (
+    <TestHeaderContainer>
+      <HeaderLeft>
+        <LeftArrowBlackBtn />
+        <TestTitle>중앙대학교 - 2021 인문사회 1</TestTitle>
+      </HeaderLeft>
+      <TimerBox>
+        <Timer />
+      </TimerBox>
+      <TestCloseButton>시험 종료</TestCloseButton>
+    </TestHeaderContainer>
+  );
 }
+const TestHeaderContainer = styled.header`
+  ${commonFlex};
+
+  justify-content: space-between;
+  padding: 1.7rem 3.6rem 1.3rem;
+  box-shadow: 0 0 1.2rem 0 ${({ theme }) => theme.colors.grey_200};
+`;
+const TestCloseButton = styled(mainButtonStyle)`
+  padding: 0.6rem 1.6rem;
+  ${({ theme }) => theme.fonts.Headline5};
+`;
+const HeaderLeft = styled.div`
+  ${commonFlex};
+
+  gap: 0.8rem;
+`;
+const TestTitle = styled.h1`
+  ${({ theme }) => theme.fonts.Headline5};
+`;
+const TimerBox = styled(lightBlueButtonStyle)`
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%);
+  padding: 0.8rem 2rem;
+`;

--- a/nonsoolmateClient/src/takeTest/components/TestHeader.tsx
+++ b/nonsoolmateClient/src/takeTest/components/TestHeader.tsx
@@ -13,7 +13,7 @@ export default function TestHeader() {
       <TimerBox>
         <Timer />
       </TimerBox>
-      <TestCloseButton>시험 종료</TestCloseButton>
+      <TestCloseButton type="button">시험 종료</TestCloseButton>
     </TestHeaderContainer>
   );
 }

--- a/nonsoolmateClient/src/takeTest/components/Timer.tsx
+++ b/nonsoolmateClient/src/takeTest/components/Timer.tsx
@@ -1,3 +1,9 @@
+import styled from "styled-components";
+
 export default function Timer() {
-  return <div>Timer</div>;
+  return <TimerContainer>01 : 00 : 00</TimerContainer>;
 }
+
+const TimerContainer = styled.p`
+  ${({ theme }) => theme.fonts.Headline4};
+`;

--- a/nonsoolmateClient/src/takeTest/index.tsx
+++ b/nonsoolmateClient/src/takeTest/index.tsx
@@ -1,3 +1,5 @@
+import TestHeader from "./components/TestHeader";
+
 export default function index() {
-  return <div>testpage</div>;
+  return <TestHeader />;
 }


### PR DESCRIPTION
## 🔥 Related Issues
- close #11

## 💙 작업 내용
- [x] takeTestPage의 헤더 구현
- [x] takeTestPage 라우터에 추가

## ✅ PR Point
- takeTestPage에 헤더 추가했습니다.
- 라우터 예시 페이지(@page/Main) 삭제하고 ./takeTest path로 takeTestPage 추가했습니다!

## 👀 스크린샷 / GIF / 링크
<img width="1512" alt="스크린샷 2024-01-06 오후 8 04 11" src="https://github.com/nonsoolmate/NONSOOLMATE-CLIENT/assets/102568726/98da6866-5449-45f7-9e0d-7982f255bb26">
