### PR TITLE
Init/#3/my place/foldering

### DIFF
--- a/nonsoolmateClient/src/home/components/HomeHeader.tsx
+++ b/nonsoolmateClient/src/home/components/HomeHeader.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+
+export default function HomeHeader() {
+  return (
+    <>
+      <Header>
+        <Logo>테스트입니다</Logo>
+        <HeaderInfo>테스트입니다</HeaderInfo>
+      </Header>
+    </>
+  );
+}
+
+const Header = styled.header`
+  display: flex;
+`;
+
+const Logo = styled.button`
+  display: flex;
+`;
+
+const HeaderInfo = styled.span`
+  display: flex;
+`;

--- a/nonsoolmateClient/src/home/components/HomePractice.tsx
+++ b/nonsoolmateClient/src/home/components/HomePractice.tsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+export default function HomePractice() {
+  return (
+    <>
+      <Header>나의 연습장</Header>
+      <Content></Content>
+    </>
+  );
+}
+
+const Header = styled.h2`
+  display: flex;
+`;
+
+const Content = styled.section`
+  display: flex;
+`;

--- a/nonsoolmateClient/src/home/components/HomeSide.tsx
+++ b/nonsoolmateClient/src/home/components/HomeSide.tsx
@@ -1,0 +1,53 @@
+import { useNavigate } from "react-router-dom";
+import { SideBarButtonLayout } from "style/layout/SideBarButtonLayout";
+import styled from "styled-components";
+
+export default function HomeSide() {
+  const navigate = useNavigate();
+
+  function handleMoveToHomePractice() {
+    navigate("/home/practice");
+  }
+  function handleMoveToHomeStudy() {
+    navigate("/home/study");
+  }
+  function handleMoveToHomeTest() {
+    navigate("/home/test");
+  }
+  return (
+    <>
+      <Side>
+        <SideHeader>테스트입니다</SideHeader>
+        <SideBar>
+          <SideBarStudyButton onClick={handleMoveToHomeStudy}></SideBarStudyButton>
+          <SideBarPracticeButton onClick={handleMoveToHomePractice}></SideBarPracticeButton>
+          <SideBarTestButton onClick={handleMoveToHomeTest}></SideBarTestButton>
+        </SideBar>
+      </Side>
+    </>
+  );
+}
+
+const Side = styled.aside`
+  display: flex;
+`;
+
+const SideHeader = styled.h1`
+  display: flex;
+`;
+
+const SideBar = styled.section`
+  display: flex;
+`;
+
+const SideBarStudyButton = styled.button`
+  ${SideBarButtonLayout}
+`;
+
+const SideBarPracticeButton = styled.button`
+  ${SideBarButtonLayout}
+`;
+
+const SideBarTestButton = styled.button`
+  ${SideBarButtonLayout}
+`;

--- a/nonsoolmateClient/src/home/components/HomeStudy.tsx
+++ b/nonsoolmateClient/src/home/components/HomeStudy.tsx
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+export default function HomeStudy() {
+  return (
+    <>
+      <Header>나의 학습장</Header>
+      <Content></Content>
+    </>
+  );
+}
+
+const Header = styled.h2`
+  display: flex;
+`;
+
+const Content = styled.section`
+  display: flex;
+`;

--- a/nonsoolmateClient/src/home/components/HomeTest.tsx
+++ b/nonsoolmateClient/src/home/components/HomeTest.tsx
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+import HomeTestSet from "./HomeTestSet";
+import HomeTestUnset from "./HomeTestUnset";
+
+export default function HomeTest() {
+  return (
+    <>
+      {/* {none&&<HomeTestUnset/>}
+      {!none&&<HomeTestSet/>} */}
+    </>
+  );
+}
+

--- a/nonsoolmateClient/src/home/components/HomeTestSet.tsx
+++ b/nonsoolmateClient/src/home/components/HomeTestSet.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function HomeTestSet() {
+  return (
+    <div>HomeTestSet</div>
+  )
+}

--- a/nonsoolmateClient/src/home/components/HomeTestUnset.tsx
+++ b/nonsoolmateClient/src/home/components/HomeTestUnset.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function HomeTestUnset() {
+  return (
+    <div>HomeTestUnset</div>
+  )
+}

--- a/nonsoolmateClient/src/home/index.tsx
+++ b/nonsoolmateClient/src/home/index.tsx
@@ -1,0 +1,21 @@
+import { Outlet } from "react-router-dom";
+import styled from "styled-components";
+import HomeHeader from "./components/HomeHeader";
+import HomeSide from "./components/HomeSide";
+
+export default function index() {
+  return (
+    <>
+      <HomeHeader />
+      <HomeSide />
+      <Homes>
+        <Outlet />
+      </Homes>
+    </>
+  );
+}
+
+//padding 좌우만 + 대학 스크롤 기능 + 배경색 light-grey
+const Homes = styled.section`
+  display: flex;
+`;

--- a/nonsoolmateClient/src/router.tsx
+++ b/nonsoolmateClient/src/router.tsx
@@ -2,12 +2,27 @@ import Error from "error";
 import Main from "@pages/Main";
 import { createBrowserRouter } from "react-router-dom";
 import RootLayout from "layout/RootLayout";
+import Home from "home";
+import HomePractice from "home/components/HomePractice";
+import HomeStudy from "home/components/HomeStudy";
+import HomeTest from "home/components/HomeTest";
 
 export const router = createBrowserRouter([
   {
     path: "/",
     element: <RootLayout />,
     errorElement: <Error />,
-    children: [{ path: "/example", element: <Main /> }],
+    children: [
+      { path: "/example", element: <Main /> },
+      {
+        path: "/home",
+        element: <Home />,
+        children: [
+          { path: "/home/practice", element: <HomePractice /> },
+          { path: "/home/study", element: <HomeStudy /> },
+          { path: "/home/test", element: <HomeTest /> },
+        ],
+      },
+    ],
   },
 ]);

--- a/nonsoolmateClient/src/style/layout/SideBarButtonLayout.ts
+++ b/nonsoolmateClient/src/style/layout/SideBarButtonLayout.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const SideBarButtonLayout = styled.button`
+  height: 10rem;
+`;


### PR DESCRIPTION
## 🔥 Related Issues
- close #3 

## 💙 작업 내용
- [x] Home페이지 뷰의 폴더 구조를 정리했습니다
- [ ] 폴더와 파일 구조만 짰기 때문에 스타일은 그냥 테스트용으로 더미값을 넣었습니다. 코리할 때 참고 부탁드려용
- [ ] 제가 맡은 뷰 페이지의 기존 네이밍 my place -> home(디자인팀 의견)으로 변경했습니다.

## ✅ PR Point
- outlet을 이용해서 **Home페이지**의 **HomeHeader와 HomeSide는 고정**이고
   Homes안에 들어갈 내용들(HomePractice 나의 연습장, HomeStudy 나의 학습장, HomeTest 나의 시험장)만 바뀌도록 라우터를 짰습니다

index.tsx
```
export default function index() {
  return (
    <>
      <HomeHeader />
      <HomeSide />
      <Homes>
        <Outlet />
      </Homes>
    </>
  );
}
```

라우터.tsx
```
      {
        path: "/home",
        element: <Home />,
        children: [
          { path: "/home/practice", element: <HomePractice /> },
          { path: "/home/study", element: <HomeStudy /> },
          { path: "/home/test", element: <HomeTest /> },
        ],
      },
```

## 😡 Trouble Shooting
- outlet jsx에러가 났는데 yarn을 하지 않아서 발생한 이슈였습니다
