### PR TITLE
Feat/#66/home/resolve selected university toggle

### DIFF
--- a/nonsoolmateClient/src/home/components/HomeHeader.tsx
+++ b/nonsoolmateClient/src/home/components/HomeHeader.tsx
@@ -3,18 +3,19 @@ import { commonFlex } from "style/commonStyle";
 import { LogoIc, LoginInfoIc, DownArrowGreyIc, UpArrowGreyIc } from "@assets/index";
 import { useState } from "react";
 import HomeMemberInfoToggle from "./HomeMemberInfoToggle";
+import { useNavigate } from "react-router-dom";
 
 export default function HomeHeader() {
   const [showMemberInfo, setShowMemberInfo] = useState<boolean>(false);
-
   const handleHomeMemberInfoToggle = () => {
     setShowMemberInfo((open) => !open);
   };
+  const navigate = useNavigate();
 
   return (
     <>
       <Header>
-        <LogoButton type="button">
+        <LogoButton type="button" onClick={() => navigate("/onBording")}>
           <LogoIcon />
         </LogoButton>
         <HeaderInfo>

--- a/nonsoolmateClient/src/home/components/UniversityModal.tsx
+++ b/nonsoolmateClient/src/home/components/UniversityModal.tsx
@@ -29,15 +29,17 @@ export default function UniversityModal(props: UniversityModalProps) {
             const { universityName, universityCategory, universityId } = data;
             const isChecked = selectedUniversityIdList.includes(universityId);
             return (
-              <CheckBox key={universityName} $isChecked={isChecked}>
+              <CheckBoxButton
+                key={universityName}
+                type="button"
+                $isChecked={isChecked}
+                onClick={() => handleUpdateUniversityIdList(universityId)}>
                 <UniversityBox>
                   <University>{universityName}</University>
                   <Category>{universityCategory}</Category>
                 </UniversityBox>
-                <CheckBoxButton type="button" onClick={() => handleUpdateUniversityIdList(universityId)}>
-                  {isChecked ? <CheckBtnIcon /> : <NotCheckBtnIcon />}
-                </CheckBoxButton>
-              </CheckBox>
+                <CheckBox>{isChecked ? <CheckBtnIcon /> : <NotCheckBtnIcon />}</CheckBox>
+              </CheckBoxButton>
             );
           })}
         </Container>
@@ -101,7 +103,7 @@ const Container = styled.section`
   margin-bottom: 22.4rem;
 `;
 
-const CheckBox = styled.div<{ $isChecked: boolean }>`
+const CheckBoxButton = styled.button<{ $isChecked: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -119,7 +121,7 @@ const UniversityBox = styled.div`
   align-items: center;
 `;
 
-const CheckBoxButton = styled.button`
+const CheckBox = styled.div`
   padding: 0;
   cursor: pointer;
 `;

--- a/nonsoolmateClient/src/home/homePractice/HomePractice.tsx
+++ b/nonsoolmateClient/src/home/homePractice/HomePractice.tsx
@@ -29,8 +29,6 @@ const Header = styled.h3`
 
 const Content = styled.section`
   ${UnsetContentLayout}
-
-  padding: 14.6rem 0;
 `;
 
 const EmptyIcon = styled(EmptyIc)`

--- a/nonsoolmateClient/src/home/homeStudy/HomeStudy.tsx
+++ b/nonsoolmateClient/src/home/homeStudy/HomeStudy.tsx
@@ -29,8 +29,6 @@ const Header = styled.h3`
 
 const Content = styled.section`
   ${UnsetContentLayout}
-
-  padding: 14.6rem 0;
 `;
 
 const EmptyIcon = styled(EmptyIc)`

--- a/nonsoolmateClient/src/home/homeTest/HomeTestSet.tsx
+++ b/nonsoolmateClient/src/home/homeTest/HomeTestSet.tsx
@@ -14,10 +14,14 @@ interface HomeTestSetProps {
 export default function HomeTestSet(props: HomeTestSetProps) {
   const { handleUniversityModal, selectedUniversityIdList } = props;
 
-  const [selectedUniversityId, setSelectedUniversityId] = useState<number | null>(null);
+  const [selectedUniversityId, setSelectedUniversityId] = useState<number[]>([]);
 
   function handleSelectedUniversityId(id: number) {
-    setSelectedUniversityId((prevId) => (prevId === id ? null : id));
+    if (selectedUniversityId.includes(id)) {
+      setSelectedUniversityId((prevSelectedIds) => prevSelectedIds.filter((selectedId) => selectedId !== id));
+    } else {
+      setSelectedUniversityId((prevSelectedIds) => [...prevSelectedIds, id]);
+    }
   }
 
   return (
@@ -36,7 +40,7 @@ export default function HomeTestSet(props: HomeTestSetProps) {
       <ListBox>
         {universityLists.map((data) => {
           const { universityId, universityName, universityCategory, examList } = data;
-          const isSelected = selectedUniversityId === universityId;
+          const isSelected = selectedUniversityId.includes(universityId);
           const isExisted = selectedUniversityIdList.includes(universityId);
 
           return (
@@ -107,6 +111,7 @@ const ListBox = styled.section`
 const SelectedListBox = styled.div`
   padding: 0;
 `;
+
 const SelectedUniversityButton = styled.button<{ $isSelected: boolean }>`
   display: flex;
   justify-content: space-between;

--- a/nonsoolmateClient/src/home/homeTest/HomeTestUnset.tsx
+++ b/nonsoolmateClient/src/home/homeTest/HomeTestUnset.tsx
@@ -43,8 +43,6 @@ const Header = styled.p`
 
 const Content = styled.section`
   ${UnsetContentLayout}
-
-  padding: 14.6rem 0;
 `;
 
 const HomeTestUnsetIcon = styled(HomeTestUnsetIc)`


### PR DESCRIPTION
## 🔥 Related Issues
- close #66 

## 💙 작업 내용
- [x] 각 대학별 시험리스트 토글 열고 닫기 이슈 해결

## ✅ PR Point
- 기존에는 하나의 버튼 열고 닫고 기능만 구현한 상태
```
  const [selectedUniversityId, setSelectedUniversityId] = useState<number | null>(null);

  function handleSelectedUniversityId(id: number) {
    setSelectedUniversityId((prevId) => (prevId === id ? null : id));
  }
```
- 버튼을 눌렀을 때 해당 대학의 토글만 닫히게 하기 위해 개별 버튼이 아닌 리스트를 filtering한다
```
  const { handleUniversityModal, selectedUniversityIdList, handleSelectedUniversityIdList } = props;

  function handleUpdateUniversityIdList(universityId: number) {
    const updatedSelectedUniversityIdList = selectedUniversityIdList.includes(universityId)
      ? selectedUniversityIdList.filter((id) => id !== universityId)
      : [...selectedUniversityIdList, universityId];

    handleSelectedUniversityIdList(updatedSelectedUniversityIdList);
  }
```

## 😡 Trouble Shooting
homeTestSet페이지의 대학의 파란 버튼을 눌렀을 때 그 대학의 시험 리스트들이 보이게하는 토글이 열린다. ⇒ (o)
**But,** 열리지 않은 다른 파란 버튼을 눌렀을 때 열려있는 대학 토글이 자동으로 닫히는 이슈가 발생했다. 

## 👀 스크린샷 / GIF / 링크


https://github.com/nonsoolmate/NONSOOLMATE-CLIENT/assets/120544840/31f60042-d952-43ed-8d9a-786030ed4b8e

