### PR TITLE
Feat/#91/take test/exam images api

### DIFF
--- a/nonsoolmateClient/src/takeTest/api/getUniversityExamImages.ts
+++ b/nonsoolmateClient/src/takeTest/api/getUniversityExamImages.ts
@@ -1,8 +1,6 @@
-import axios from "axios";
+import { client } from "@api/axios";
 export async function getUniversityExamImages(pageNum: number) {
-  const response = await axios.get(`https://placekitten.com/300/20${pageNum}`, {
-    responseType: "blob",
-  });
+  const response = await client.get(`/university/exam/1/image?page=${pageNum}`);
 
-  return URL.createObjectURL(response.data);
+  return response.data;
 }

--- a/nonsoolmateClient/src/takeTest/components/pagination/TestPagination.tsx
+++ b/nonsoolmateClient/src/takeTest/components/pagination/TestPagination.tsx
@@ -15,6 +15,8 @@ export default function TestPagination(props: PaginatinProps) {
 
   const { data } = useGetUniversityExampleImages(paperIdx);
 
+  const maxPage = data?.data.totalPages;
+
   function handleMoveToPreviousPage() {
     setPaperIdx((prev) => prev - 1);
   }
@@ -26,8 +28,11 @@ export default function TestPagination(props: PaginatinProps) {
       <PreviousPageButton type="button" onClick={handleMoveToPreviousPage} disabled={paperIdx === 0}>
         <LeftArrowBigIcon />
       </PreviousPageButton>
-      <TestImage src={openCoachMark || openPrecautionModal ? testExample : data} alt="시험지 이미지" />
-      <NextPageButton type="button" onClick={handleMoveToNextPage}>
+      <TestImage
+        src={openCoachMark || openPrecautionModal ? testExample : data?.data.content[0].examImgUrl}
+        alt="시험지 이미지"
+      />
+      <NextPageButton type="button" onClick={handleMoveToNextPage} disabled={paperIdx === maxPage - 1}>
         <RightArrowBigIcon />
       </NextPageButton>
     </TestPaginationContainer>


### PR DESCRIPTION
## 🔥 Related Issues
- close #91

## 💙 작업 내용
- [x] takeTestPage 문제지(페이지네이션) api 연결
- [x] 받아온 이미지 url 이용해서 시험지 보여주기
- [x] 받아온 총 페이지 수로 버튼에 disabled 적용

## ✅ PR Point
- 션💙 언니가 만들어준 axios instance 이용했습니당
## 😡 Trouble Shooting
처음에 api 연결할 때 cors 에러가 떴는데 서버에 얘기해서 해결해주셨습니다!
## 👀 스크린샷 / GIF / 링크


https://github.com/nonsoolmate/NONSOOLMATE-CLIENT/assets/102568726/855c4066-261a-4dbb-b5e8-6eb99b133e1b

