### PR TITLE
Feat/#98/take test/presigned url api

### DIFF
--- a/nonsoolmateClient/src/takeTest/api/getPresignedUrl.ts
+++ b/nonsoolmateClient/src/takeTest/api/getPresignedUrl.ts
@@ -1,6 +1,10 @@
 import { client } from "@api/axios";
-
+import { Response } from "types/common";
+interface DataTypes {
+  resultFileName: string;
+  preSignedUrl: string;
+}
 export async function getPresignedUrl() {
-  const response = await client.get("/university/exam-record/sheet/presigned");
-  return response.data;
+  const { data } = await client.get<Response<DataTypes>>("/university/exam-record/sheet/presigned");
+  return data;
 }

--- a/nonsoolmateClient/src/takeTest/api/getPresignedUrl.ts
+++ b/nonsoolmateClient/src/takeTest/api/getPresignedUrl.ts
@@ -1,0 +1,6 @@
+import { client } from "@api/axios";
+
+export async function getPresignedUrl() {
+  const response = await client.get("/university/exam-record/sheet/presigned");
+  return response.data;
+}

--- a/nonsoolmateClient/src/takeTest/api/getUniversityExam.ts
+++ b/nonsoolmateClient/src/takeTest/api/getUniversityExam.ts
@@ -1,6 +1,12 @@
 import { client } from "@api/axios";
-export async function getUniversityExam(id: number) {
-  const response = await client.get(`/university/exam/${id}/info`);
+import { Response } from "types/common";
+export interface DataTypes {
+  examId: number;
+  examName: string;
+  examTimeLimit: number;
+}
 
-  return response.data;
+export async function getUniversityExam(id: number) {
+  const { data } = await client.get<Response<DataTypes>>(`/university/exam/${id}/info`);
+  return data;
 }

--- a/nonsoolmateClient/src/takeTest/api/getUniversityExam.ts
+++ b/nonsoolmateClient/src/takeTest/api/getUniversityExam.ts
@@ -1,6 +1,6 @@
 import { client } from "@api/axios";
 import { Response } from "types/common";
-export interface DataTypes {
+interface DataTypes {
   examId: number;
   examName: string;
   examTimeLimit: number;

--- a/nonsoolmateClient/src/takeTest/api/getUniversityExamImages.ts
+++ b/nonsoolmateClient/src/takeTest/api/getUniversityExamImages.ts
@@ -1,6 +1,43 @@
 import { client } from "@api/axios";
+import { Response } from "types/common";
+interface DataTypes {
+  content: ContentItem[];
+  pageable: Pageable;
+  totalPages: number;
+  totalElements: number;
+  last: boolean;
+  size: number;
+  number: number;
+  sort: Sort;
+  numberOfElements: number;
+  first: boolean;
+  empty: boolean;
+}
+interface ContentItem {
+  examImgUrl: string;
+}
+
+interface PageableSort {
+  empty: boolean;
+  sorted: boolean;
+  unsorted: boolean;
+}
+
+interface Pageable {
+  pageNumber: number;
+  pageSize: number;
+  sort: PageableSort;
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+}
+interface Sort {
+  empty: boolean;
+  sorted: boolean;
+  unsorted: boolean;
+}
 export async function getUniversityExamImages(pageNum: number) {
-  const response = await client.get(`/university/exam/1/image?page=${pageNum}`);
+  const response = await client.get<Response<DataTypes>>(`/university/exam/1/image?page=${pageNum}`);
 
   return response.data;
 }

--- a/nonsoolmateClient/src/takeTest/api/getUniversityExamImages.ts
+++ b/nonsoolmateClient/src/takeTest/api/getUniversityExamImages.ts
@@ -37,7 +37,7 @@ interface Sort {
   unsorted: boolean;
 }
 export async function getUniversityExamImages(pageNum: number) {
-  const response = await client.get<Response<DataTypes>>(`/university/exam/1/image?page=${pageNum}`);
+  const { data } = await client.get<Response<DataTypes>>(`/university/exam/1/image?page=${pageNum}`);
 
-  return response.data;
+  return data;
 }

--- a/nonsoolmateClient/src/takeTest/components/pagination/TestPagination.tsx
+++ b/nonsoolmateClient/src/takeTest/components/pagination/TestPagination.tsx
@@ -4,6 +4,7 @@ import testExample from "@assets/image/testexample.png";
 import { commonFlex } from "style/commonStyle";
 import { useState } from "react";
 import { useGetUniversityExampleImages } from "takeTest/hooks/useGetUniversityExampleImages";
+import Error from "error";
 
 interface PaginatinProps {
   openCoachMark: boolean;
@@ -14,7 +15,7 @@ export default function TestPagination(props: PaginatinProps) {
   const [paperIdx, setPaperIdx] = useState(0);
 
   const examImage = useGetUniversityExampleImages(paperIdx);
-  if (!examImage) return null;
+  if (!examImage) return <Error />;
   const {
     data: { totalPages, content },
   } = examImage;

--- a/nonsoolmateClient/src/takeTest/components/pagination/TestPagination.tsx
+++ b/nonsoolmateClient/src/takeTest/components/pagination/TestPagination.tsx
@@ -13,11 +13,11 @@ export default function TestPagination(props: PaginatinProps) {
   const { openCoachMark, openPrecautionModal } = props;
   const [paperIdx, setPaperIdx] = useState(0);
 
-  const ExamImage = useGetUniversityExampleImages(paperIdx);
-  if (!ExamImage) return null;
+  const examImage = useGetUniversityExampleImages(paperIdx);
+  if (!examImage) return null;
   const {
     data: { totalPages, content },
-  } = ExamImage;
+  } = examImage;
 
   function handleMoveToPreviousPage() {
     setPaperIdx((prev) => prev - 1);

--- a/nonsoolmateClient/src/takeTest/components/pagination/TestPagination.tsx
+++ b/nonsoolmateClient/src/takeTest/components/pagination/TestPagination.tsx
@@ -13,9 +13,11 @@ export default function TestPagination(props: PaginatinProps) {
   const { openCoachMark, openPrecautionModal } = props;
   const [paperIdx, setPaperIdx] = useState(0);
 
-  const { data } = useGetUniversityExampleImages(paperIdx);
-
-  const maxPage = data?.data.totalPages;
+  const ExamImage = useGetUniversityExampleImages(paperIdx);
+  if (!ExamImage) return null;
+  const {
+    data: { totalPages, content },
+  } = ExamImage;
 
   function handleMoveToPreviousPage() {
     setPaperIdx((prev) => prev - 1);
@@ -28,11 +30,8 @@ export default function TestPagination(props: PaginatinProps) {
       <PreviousPageButton type="button" onClick={handleMoveToPreviousPage} disabled={paperIdx === 0}>
         <LeftArrowBigIcon />
       </PreviousPageButton>
-      <TestImage
-        src={openCoachMark || openPrecautionModal ? testExample : data?.data.content[0].examImgUrl}
-        alt="시험지 이미지"
-      />
-      <NextPageButton type="button" onClick={handleMoveToNextPage} disabled={paperIdx === maxPage - 1}>
+      <TestImage src={openCoachMark || openPrecautionModal ? testExample : content[0].examImgUrl} alt="시험지 이미지" />
+      <NextPageButton type="button" onClick={handleMoveToNextPage} disabled={paperIdx === totalPages - 1}>
         <RightArrowBigIcon />
       </NextPageButton>
     </TestPaginationContainer>

--- a/nonsoolmateClient/src/takeTest/hooks/useGetPresignedUrl.ts
+++ b/nonsoolmateClient/src/takeTest/hooks/useGetPresignedUrl.ts
@@ -6,10 +6,10 @@ const QUERY_KEY = {
 };
 
 export default function useGetPresignedUrl() {
-  const result = useQuery(QUERY_KEY.getPresignedUrl, () => getPresignedUrl(), {
+  const { data } = useQuery(QUERY_KEY.getPresignedUrl, () => getPresignedUrl(), {
     onError: (error) => {
       console.log("에러 발생", error);
     },
   });
-  return result;
+  return data;
 }

--- a/nonsoolmateClient/src/takeTest/hooks/useGetPresignedUrl.ts
+++ b/nonsoolmateClient/src/takeTest/hooks/useGetPresignedUrl.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "react-query";
+import { getPresignedUrl } from "takeTest/api/getPresignedUrl";
+
+const QUERY_KEY = {
+  getPresignedUrl: "getPresignedUrl",
+};
+
+export default function useGetPresignedUrl() {
+  const result = useQuery(QUERY_KEY.getPresignedUrl, () => getPresignedUrl(), {
+    onError: (error) => {
+      console.log("에러 발생", error);
+    },
+  });
+  return result;
+}

--- a/nonsoolmateClient/src/takeTest/hooks/useGetUniversityExam.ts
+++ b/nonsoolmateClient/src/takeTest/hooks/useGetUniversityExam.ts
@@ -1,8 +1,12 @@
 import { useQuery } from "react-query";
 import { getUniversityExam } from "takeTest/api/getUniversityExam";
 
+const QUERY_KEY = {
+  getUniversityExam: "getUniversityExam",
+};
+
 export function useGetUniversityExam(id: number) {
-  const { data } = useQuery(["info", id], () => getUniversityExam(id), {
+  const { data } = useQuery([QUERY_KEY.getUniversityExam, id], () => getUniversityExam(id), {
     onError: (error) => {
       console.log("에러 발생", error);
     },

--- a/nonsoolmateClient/src/takeTest/hooks/useGetUniversityExam.ts
+++ b/nonsoolmateClient/src/takeTest/hooks/useGetUniversityExam.ts
@@ -2,10 +2,10 @@ import { useQuery } from "react-query";
 import { getUniversityExam } from "takeTest/api/getUniversityExam";
 
 export function useGetUniversityExam(id: number) {
-  const result = useQuery(["info", id], () => getUniversityExam(id), {
+  const { data } = useQuery(["info", id], () => getUniversityExam(id), {
     onError: (error) => {
       console.log("에러 발생", error);
     },
   });
-  return result;
+  return data;
 }

--- a/nonsoolmateClient/src/takeTest/hooks/useGetUniversityExampleImages.ts
+++ b/nonsoolmateClient/src/takeTest/hooks/useGetUniversityExampleImages.ts
@@ -1,12 +1,16 @@
 import { useQuery } from "react-query";
 import { getUniversityExamImages } from "takeTest/api/getUniversityExamImages";
 
+const QUERY_KEY = {
+  getUniversityExamImages: "getUniversityExamImages",
+};
+
 export function useGetUniversityExampleImages(pageNum: number) {
-  const result = useQuery(["pages", pageNum], () => getUniversityExamImages(pageNum), {
+  const { data } = useQuery([QUERY_KEY.getUniversityExamImages, pageNum], () => getUniversityExamImages(pageNum), {
     keepPreviousData: true,
     onError: (error) => {
       console.log("에러 발생", error);
     },
   });
-  return result;
+  return data;
 }

--- a/nonsoolmateClient/src/takeTest/index.tsx
+++ b/nonsoolmateClient/src/takeTest/index.tsx
@@ -18,9 +18,12 @@ export default function index() {
   const [totalTime, setTotalTime] = useState(0);
   const [isFile, setIsFile] = useState<File[] | null>(null);
 
-  const { data } = useGetUniversityExam(1);
-  const examName = data?.data.examName;
-  const examTimeLimit = data?.data.examTimeLimit;
+  const ExamRes = useGetUniversityExam(1);
+  if (!ExamRes) return null;
+
+  const {
+    data: { examName, examTimeLimit },
+  } = ExamRes;
 
   const scroll = !(
     openCoachMark ||

--- a/nonsoolmateClient/src/takeTest/index.tsx
+++ b/nonsoolmateClient/src/takeTest/index.tsx
@@ -29,9 +29,9 @@ export default function index() {
     data: { examName, examTimeLimit },
   } = examRes;
 
-  const {
-    data: { resultFileName, preSignedUrl },
-  } = preSignedRes;
+  // const {
+  //   data: { resultFileName, preSignedUrl },
+  // } = preSignedRes;
 
   const scroll = !(
     openCoachMark ||

--- a/nonsoolmateClient/src/takeTest/index.tsx
+++ b/nonsoolmateClient/src/takeTest/index.tsx
@@ -9,6 +9,7 @@ import TestSubmitModal from "./components/modal/TestSubmitModal";
 import styled from "styled-components";
 import { useGetUniversityExam } from "./hooks/useGetUniversityExam";
 import useGetPresignedUrl from "./hooks/useGetPresignedUrl";
+import Error from "error";
 
 export default function index() {
   const [openCoachMark, setOpenCoachMark] = useState(true);
@@ -21,8 +22,8 @@ export default function index() {
 
   const examRes = useGetUniversityExam(1);
   const preSignedRes = useGetPresignedUrl();
-  if (!examRes) return null;
-  if (!preSignedRes) return null;
+  if (!examRes) return <Error />;
+  if (!preSignedRes) return <Error />;
 
   const {
     data: { examName, examTimeLimit },

--- a/nonsoolmateClient/src/takeTest/index.tsx
+++ b/nonsoolmateClient/src/takeTest/index.tsx
@@ -22,6 +22,7 @@ export default function index() {
   const examRes = useGetUniversityExam(1);
   const preSignedRes = useGetPresignedUrl();
   if (!examRes) return null;
+  if (!preSignedRes) return null;
 
   const {
     data: { examName, examTimeLimit },

--- a/nonsoolmateClient/src/takeTest/index.tsx
+++ b/nonsoolmateClient/src/takeTest/index.tsx
@@ -8,6 +8,7 @@ import TestFinishModal from "./components/modal/TestFinishModal";
 import TestSubmitModal from "./components/modal/TestSubmitModal";
 import styled from "styled-components";
 import { useGetUniversityExam } from "./hooks/useGetUniversityExam";
+import useGetPresignedUrl from "./hooks/useGetPresignedUrl";
 
 export default function index() {
   const [openCoachMark, setOpenCoachMark] = useState(true);
@@ -18,12 +19,17 @@ export default function index() {
   const [totalTime, setTotalTime] = useState(0);
   const [isFile, setIsFile] = useState<File[] | null>(null);
 
-  const ExamRes = useGetUniversityExam(1);
-  if (!ExamRes) return null;
+  const examRes = useGetUniversityExam(1);
+  const preSignedRes = useGetPresignedUrl();
+  if (!examRes) return null;
 
   const {
     data: { examName, examTimeLimit },
-  } = ExamRes;
+  } = examRes;
+
+  const {
+    data: { resultFileName, preSignedUrl },
+  } = preSignedRes;
 
   const scroll = !(
     openCoachMark ||

--- a/nonsoolmateClient/src/types/common.ts
+++ b/nonsoolmateClient/src/types/common.ts
@@ -1,0 +1,5 @@
+export interface Response<T> {
+  message: string;
+  code: number;
+  data: T;
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #98

## 💙 작업 내용
- [x] 공통 response 데이터타입 인스턴스 생성
- [x] 타입 추가
- [x] 답안지 업로드 PresignedUrl 조회 API (get) 

## ✅ PR Point
- 연결했었던 api에 타입 추가했습니다.
- 시연 언니💙가 전에 사용했던 방식으로 데이터 가져왔습니다!!
```javascript
export interface Response<T> {
  message: string;
  code: number;
  data: T;
}

```
```javascript
interface DataTypes {
  resultFileName: string;
  preSignedUrl: string;
}
export async function getPresignedUrl() {
  const { data } = await client.get<Response<DataTypes>>("/university/exam-record/sheet/presigned");
  return data;
}
```
```javascript
const preSignedRes = useGetPresignedUrl();
if (!preSignedRes) return null;

const {
  data: { resultFileName, preSignedUrl },
} = preSignedRes;
  ```

