### PR TITLE
[ hotfix/#118 ] 새로고침 시 리셋되는 문제 해결

### DIFF
--- a/nonsoolmateClient/src/home/components/UniversityModal.tsx
+++ b/nonsoolmateClient/src/home/components/UniversityModal.tsx
@@ -14,6 +14,8 @@ interface UniversityModalProps {
   isSelectedNone?: boolean;
   handleMySelectedUniversityIdList: (idList: number[]) => void;
   mySelectedUniversityIdList: number[];
+  dataUniversityIds: number[]
+
 }
 
 export default function UniversityModal(props: UniversityModalProps) {
@@ -23,9 +25,14 @@ export default function UniversityModal(props: UniversityModalProps) {
     handleSelectedUniversityIdList,
     isSelectedNone,
     handleMySelectedUniversityIdList,
+    dataUniversityIds
   } = props;
 
   const mutate = usePatchSelectUniversities();
+
+useEffect(() => {
+  handleSelectedUniversityIdList(dataUniversityIds)
+}, [])
 
   useEffect(() => {
     if (isSelectedNone) {
@@ -42,6 +49,7 @@ export default function UniversityModal(props: UniversityModalProps) {
   }
 
   function cancel() {
+    //localstorage에 저장된 리스트 불러오기 + 타입에 맞게 파싱작업
     const savedData = localStorage.getItem("backList");
     const parsedData = savedData ? JSON.parse(savedData) : [];
     handleSelectedUniversityIdList(parsedData);
@@ -58,6 +66,7 @@ export default function UniversityModal(props: UniversityModalProps) {
 
   const getSelectUniversitiesResponse = useGetSelectUniversities();
   if (!getSelectUniversitiesResponse) return <Error />;
+
 
   return (
     <BackgroundView>

--- a/nonsoolmateClient/src/home/homeTest/HomeTest.tsx
+++ b/nonsoolmateClient/src/home/homeTest/HomeTest.tsx
@@ -17,7 +17,6 @@ export default function HomeTest() {
 
   const response = useGetSelectUniversityExams();
   if (!response) return <Error />;
-  console.log(response);
 
   const dataUniversityIds = response.map((item) => item.universityId);
 

--- a/nonsoolmateClient/src/home/homeTest/HomeTest.tsx
+++ b/nonsoolmateClient/src/home/homeTest/HomeTest.tsx
@@ -1,12 +1,25 @@
 import HomeTestUnset from "./HomeTestUnset";
 import HomeTestSet from "./HomeTestSet";
 import UniversityModal from "home/components/UniversityModal";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import useGetSelectUniversityExams from "home/hooks/useGetSelectUniversityExams";
+import Error from "error";
 
 export default function HomeTest() {
   const [universityModal, setUniversityModal] = useState<boolean>(false);
   const [selectedUniversityIdList, setSelectedUniversityIdList] = useState<number[]>([]);
   const [mySelectedUniversityIdList, setMySelectedUniversityIdList] = useState<number[]>([]);
+
+  useEffect(() => {
+    let realArray = response?.map((item) => item.universityId);
+    realArray && handleMySelectedUniversityIdList(realArray);
+  }, []);
+
+  const response = useGetSelectUniversityExams();
+  if (!response) return <Error />;
+  console.log(response);
+
+  const dataUniversityIds = response.map((item) => item.universityId);
 
   function handleUniversityModal(open: boolean) {
     setUniversityModal(open);
@@ -22,10 +35,11 @@ export default function HomeTest() {
 
   return (
     <>
-      {mySelectedUniversityIdList.length > 0 ? (
+      {response.length > 0 ? (
         <HomeTestSet
           handleUniversityModal={handleUniversityModal}
-          mySelectedUniversityIdList={mySelectedUniversityIdList}
+          response={response}
+          dataUniversityIds={dataUniversityIds}
         />
       ) : (
         <HomeTestUnset handleUniversityModal={handleUniversityModal} />
@@ -38,6 +52,7 @@ export default function HomeTest() {
           handleUniversityModal={handleUniversityModal}
           handleSelectedUniversityIdList={handleSelectedUniversityIdList}
           mySelectedUniversityIdList={mySelectedUniversityIdList}
+          dataUniversityIds={dataUniversityIds}
         />
       )}
     </>

--- a/nonsoolmateClient/src/home/homeTest/HomeTestSet.tsx
+++ b/nonsoolmateClient/src/home/homeTest/HomeTestSet.tsx
@@ -4,16 +4,16 @@ import { DownArrowBoldIc, SearchIc, UpArrowBoldIc } from "@assets/index";
 import { commonFlex } from "style/commonStyle";
 import { useState } from "react";
 import SelectedUniversityToggle from "home/components/SelectedUniversityToggle";
-import Error from "error";
-import useGetSelectUniversityExams from "home/hooks/useGetSelectUniversityExams";
+import { SelectUniversityDataTypes } from "home/api/getSelectUniversityExams";
 
 interface HomeTestSetProps {
   handleUniversityModal: (open: boolean) => void;
-  mySelectedUniversityIdList: number[];
+  response: SelectUniversityDataTypes[];
+  dataUniversityIds: number[]
 }
 
 export default function HomeTestSet(props: HomeTestSetProps) {
-  const { handleUniversityModal, mySelectedUniversityIdList } = props;
+  const { handleUniversityModal, response, dataUniversityIds } = props;
   const [selectedUniversityId, setSelectedUniversityId] = useState<number[]>([]);
 
   function handleSelectedUniversityId(id: number) {
@@ -24,8 +24,6 @@ export default function HomeTestSet(props: HomeTestSetProps) {
     }
   }
 
-  const getSelectUniversityExamsResponse = useGetSelectUniversityExams();
-  if (!getSelectUniversityExamsResponse) return <Error />;
 
   return (
     <Container>
@@ -42,10 +40,10 @@ export default function HomeTestSet(props: HomeTestSetProps) {
           </HeaderButton>
         </HeaderBox>
         <ListBox>
-          {getSelectUniversityExamsResponse.map((data) => {
+          {response.map((data) => {
             const { universityId, universityName, universityCollege, examList } = data;
             const isSelected = selectedUniversityId.includes(universityId);
-            const isExisted = mySelectedUniversityIdList.includes(universityId);
+            const isExisted = dataUniversityIds.includes(universityId);
 
             return (
               <SelectedListBox key={universityId}>

--- a/nonsoolmateClient/src/home/hooks/useGetSelectUniversityExams.ts
+++ b/nonsoolmateClient/src/home/hooks/useGetSelectUniversityExams.ts
@@ -6,10 +6,6 @@ export default function useGetSelectUniversityExams() {
     onError: (error) => {
       console.log("에러 발생", error);
     },
-    onSuccess: () => {
-      console.log("성공");
-      //queryClient.invalidateQueries("getSelectUniversityExams");
-    },
   });
   return data;
 }

--- a/nonsoolmateClient/src/home/hooks/useGetSelectUniversityExams.ts
+++ b/nonsoolmateClient/src/home/hooks/useGetSelectUniversityExams.ts
@@ -1,11 +1,14 @@
 import { getSelectUniversityExams } from "home/api/getSelectUniversityExams";
-
 import { useQuery } from "react-query";
 
 export default function useGetSelectUniversityExams() {
   const { data } = useQuery("getSelectUniversityExams", () => getSelectUniversityExams(), {
     onError: (error) => {
       console.log("에러 발생", error);
+    },
+    onSuccess: () => {
+      console.log("성공");
+      //queryClient.invalidateQueries("getSelectUniversityExams");
     },
   });
   return data;


### PR DESCRIPTION
## 🔥 Related Issues
- close #118 

## 💙 작업 내용
- [x] 새로고침 시 리셋되는 문제 해결

## 😡 Trouble Shooting
- 새로고침 이슈 해결 -> 처음 Home페이지 보여줄 때도 get으로 서버에 저장되어있는 데이터를 불러와야했다
```
{response.length > 0 ? (
```

- realArray를 mySelectedUniversityIdList에 저장하는 작업을 useEffect를 씀으로써 리렌더링 많이되는 에러를 해결한다.
```
  useEffect(() => {
    let realArray = response?.map((item) => item.universityId);
    realArray && handleMySelectedUniversityIdList(realArray);
  }, []);

  const response = useGetSelectUniversityExams();
  if (!response) return <Error />;
  console.log(response);

  const dataUniversityIds = response.map((item) => item.universityId);
```

## 💙 
- 시연언니 차분하게 내코드 보면서 해결해줘서 너무 고마워🥺🥺